### PR TITLE
Transition must return bool indicating success 

### DIFF
--- a/robot_activity/include/robot_activity/managed_robot_activity.h
+++ b/robot_activity/include/robot_activity/managed_robot_activity.h
@@ -108,12 +108,16 @@ private:
   /**
    * @brief Overriden onConfigure, which calls onManagedConfigure. Cannot be
    *        overriden further by the child class of ManagedRobotActivity.
+   *
+   * @return Returns true if onManagedConfigure succeeded
    */
   bool onConfigure() final;
 
   /**
    * @brief Overriden onUnconfigure, which calls onManagedUnconfigure. Cannot be
    *        overriden further by the child class of ManagedRobotActivity.
+   *
+   * @return Returns true if onManagedUnconfigure succeeded
    */
   bool onUnconfigure() final;
 
@@ -123,6 +127,8 @@ private:
    *        It subscribes and adverties all ROS topics and services that were
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
+   *
+   * @return Returns true if onManagedStart succeeded
    */
   bool onStart() final;
 
@@ -132,6 +138,8 @@ private:
    *        It shutdowns all ROS topics and services that were
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
+   *
+   * @return Returns true if onManagedStop succeeded
    */
   bool onStop() final;
 
@@ -141,6 +149,8 @@ private:
    *        It pauses all ROS topics and services that were
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
+   *
+   * @return Returns true if onManagedPause succeeded
    */
   bool onPause() final;
 
@@ -150,12 +160,14 @@ private:
    *        It resumes all ROS topics and services that were
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
+   *
+   * @return Returns true if onManagedResume succeeded
    */
   bool onResume() final;
 
   /**
    * @brief User-defined function that's called at the end of transition from
-   *        LAUNCHING to UNCONFIGURED state
+   *        LAUNCHING to UNCONFIGURED state.
    */
   virtual void onManagedCreate() = 0;
 
@@ -168,36 +180,66 @@ private:
   /**
    * @brief User-defined function that's called at the end of transition from
    *        UNCONFIGURED to STOPPED state
+   *        User has to return true or false, indicating whether the transition
+   *        has succeeded or not. In case of failure, the state remains
+   *        unchanged
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onManagedConfigure() = 0;
 
   /**
   * @brief User-defined function that's called at the end of transition from
   *        STOPPED to UNCONFIGURED state
+  *        User has to return true or false, indicating whether the transition
+  *        has succeeded or not. In case of failure, the state remains
+  *        unchanged
+  *
+  * @return Returns true if transition succeeded
   */
   virtual bool onManagedUnconfigure() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        STOPPED to PAUSED state
+   *        User has to return true or false, indicating whether the transition
+   *        has succeeded or not. In case of failure, the state remains
+   *        unchanged
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onManagedStart() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        PAUSED to STOPPED state
+   *        User has to return true or false, indicating whether the transition
+   *        has succeeded or not. In case of failure, the state remains
+   *        unchanged
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onManagedStop() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        RUNNING to PAUSED state
+   *        User has to return true or false, indicating whether the transition
+   *        has succeeded or not. In case of failure, the state remains
+   *        unchanged
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onManagedPause() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        PAUSED to RUNNING state
+   *        User has to return true or false, indicating whether the transition
+   *        has succeeded or not. In case of failure, the state remains
+   *        unchanged
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onManagedResume() = 0;
 };

--- a/robot_activity/include/robot_activity/managed_robot_activity.h
+++ b/robot_activity/include/robot_activity/managed_robot_activity.h
@@ -109,13 +109,13 @@ private:
    * @brief Overriden onConfigure, which calls onManagedConfigure. Cannot be
    *        overriden further by the child class of ManagedRobotActivity.
    */
-  void onConfigure() final;
+  bool onConfigure() final;
 
   /**
    * @brief Overriden onUnconfigure, which calls onManagedUnconfigure. Cannot be
    *        overriden further by the child class of ManagedRobotActivity.
    */
-  void onUnconfigure() final;
+  bool onUnconfigure() final;
 
   /**
    * @brief Overriden onStart, which calls onManagedStart. Cannot be
@@ -124,7 +124,7 @@ private:
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
    */
-  void onStart() final;
+  bool onStart() final;
 
   /**
    * @brief Overriden onStop, which calls onManagedStop. Cannot be
@@ -133,7 +133,7 @@ private:
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
    */
-  void onStop() final;
+  bool onStop() final;
 
   /**
    * @brief Overriden onPause, which calls onManagedPause. Cannot be
@@ -142,7 +142,7 @@ private:
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
    */
-  void onPause() final;
+  bool onPause() final;
 
   /**
    * @brief Overriden onResume, which calls onManagedResume. Cannot be
@@ -151,7 +151,7 @@ private:
    *        subscribed and advertised with subscription_manager
    *        and service_manager before calling onManagedStart.
    */
-  void onResume() final;
+  bool onResume() final;
 
   /**
    * @brief User-defined function that's called at the end of transition from
@@ -169,37 +169,37 @@ private:
    * @brief User-defined function that's called at the end of transition from
    *        UNCONFIGURED to STOPPED state
    */
-  virtual void onManagedConfigure() = 0;
+  virtual bool onManagedConfigure() = 0;
 
   /**
   * @brief User-defined function that's called at the end of transition from
   *        STOPPED to UNCONFIGURED state
   */
-  virtual void onManagedUnconfigure() = 0;
+  virtual bool onManagedUnconfigure() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        STOPPED to PAUSED state
    */
-  virtual void onManagedStart() = 0;
+  virtual bool onManagedStart() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        PAUSED to STOPPED state
    */
-  virtual void onManagedStop() = 0;
+  virtual bool onManagedStop() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        RUNNING to PAUSED state
    */
-  virtual void onManagedPause() = 0;
+  virtual bool onManagedPause() = 0;
 
   /**
    * @brief User-defined function that's called at the end of transition from
    *        PAUSED to RUNNING state
    */
-  virtual void onManagedResume() = 0;
+  virtual bool onManagedResume() = 0;
 };
 
 }  // namespace robot_activity

--- a/robot_activity/include/robot_activity/robot_activity.h
+++ b/robot_activity/include/robot_activity/robot_activity.h
@@ -325,77 +325,77 @@ private:
    * @brief Function to be defined by the user.
    *        Called at the end of transition from UNCONFIGURED to STOPPED.
    */
-  virtual void onConfigure() = 0;
+  virtual bool onConfigure() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from STOPPED to UNCONFIGURED.
    */
-  virtual void onUnconfigure() = 0;
+  virtual bool onUnconfigure() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from STOPPED to PAUSED.
    */
-  virtual void onStart() = 0;
+  virtual bool onStart() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from PAUSED to STOPPED.
    */
-  virtual void onStop() = 0;
+  virtual bool onStop() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from RUNNING to PAUSED.
    */
-  virtual void onPause() = 0;
+  virtual bool onPause() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from PAUSED to RUNNING.
    */
-  virtual void onResume() = 0;
+  virtual bool onResume() = 0;
 
   /**
    * @brief Called automatically, when transition from LAUNCHING to UNCONFIGURED.
    */
-  void create();
+  bool create();
 
   /**
    * @brief Called automatically, when transition from UNCONFIGURED to TERMINATED.
    */
-  void terminate();
+  bool terminate();
 
   /**
    * @brief Called automatically, when transition from UNCONFIGURED to STOPPED.
    */
-  void configure();
+  bool configure();
 
   /**
    * @brief Called automatically, when transition from STOPPED to UNCONFIGURED.
    */
-  void unconfigure();
+  bool unconfigure();
 
   /**
    * @brief Called automatically, when transition from STOPPED to PAUSED.
    */
-  void start();
+  bool start();
 
   /**
    * @brief Called automatically, when transition from PAUSED to STOPPED.
    */
-  void stop();
+  bool stop();
 
   /**
    * @brief Called automatically, when transition from PAUSED to RUNNING.
    */
-  void resume();
+  bool resume();
 
   /**
    * @brief Called automatically, when transition from RUNNING to PAUSED.
    */
-  void pause();
+  bool pause();
 
   /**
    * @brief Sends a heartbeat message with the current state
@@ -408,7 +408,7 @@ private:
    *
    * @param new_state State to transition to.
    */
-  void changeState(const State& new_state);
+  bool changeState(const State& new_state);
 
   /**
    * @brief Transitions to a new state. Path must exists between the current
@@ -432,7 +432,7 @@ private:
     const std::string& service_name,
     const std::vector<State>& states);
 
-  typedef void (RobotActivity::*MemberLambdaCallback)();
+  typedef bool (RobotActivity::*MemberLambdaCallback)();
 
   typedef boost::function < bool(
     std_srvs::Empty::Request& req,

--- a/robot_activity/include/robot_activity/robot_activity.h
+++ b/robot_activity/include/robot_activity/robot_activity.h
@@ -324,76 +324,124 @@ private:
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from UNCONFIGURED to STOPPED.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onConfigure() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from STOPPED to UNCONFIGURED.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onUnconfigure() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from STOPPED to PAUSED.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onStart() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from PAUSED to STOPPED.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onStop() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from RUNNING to PAUSED.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onPause() = 0;
 
   /**
    * @brief Function to be defined by the user.
    *        Called at the end of transition from PAUSED to RUNNING.
+   *        User must return true or false depending whether transition should
+   *        succeed or not.
+   *
+   * @return Returns true if transition succeeded
    */
   virtual bool onResume() = 0;
 
   /**
    * @brief Called automatically, when transition from LAUNCHING to UNCONFIGURED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onCreate.
+   * @return Returns true always.
    */
   bool create();
 
   /**
    * @brief Called automatically, when transition from UNCONFIGURED to TERMINATED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onTerminate.
+   * @return Returns true always.
    */
   bool terminate();
 
   /**
    * @brief Called automatically, when transition from UNCONFIGURED to STOPPED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onConfigure.
+   * @return Returns the result of onConfigure.
    */
   bool configure();
 
   /**
    * @brief Called automatically, when transition from STOPPED to UNCONFIGURED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onUnconfigure.
+   * @return Returns the result of onUnconfigure.
    */
   bool unconfigure();
 
   /**
    * @brief Called automatically, when transition from STOPPED to PAUSED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onStart.
+   * @return Returns the result of onStart.
    */
   bool start();
 
   /**
    * @brief Called automatically, when transition from PAUSED to STOPPED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onStop.
+   * @return Returns the result of onStop.
    */
   bool stop();
 
   /**
    * @brief Called automatically, when transition from PAUSED to RUNNING.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onResume.
+   * @return Returns the result of onResume.
    */
   bool resume();
 
   /**
    * @brief Called automatically, when transition from RUNNING to PAUSED.
+   *        RobotActivity calls this function directly during transition,
+   *        which internally calls the user-defined RobotActivity::onPause.
+   * @return Returns the result of onPause.
    */
   bool pause();
 
@@ -407,6 +455,7 @@ private:
    *        The appropriate function will be called during transition.
    *
    * @param new_state State to transition to.
+   * @return Returns true if changing state has succeeded
    */
   bool changeState(const State& new_state);
 

--- a/robot_activity/src/managed_robot_activity.cpp
+++ b/robot_activity/src/managed_robot_activity.cpp
@@ -56,48 +56,48 @@ void ManagedRobotActivity::onTerminate()
   onManagedTerminate();
 }
 
-void ManagedRobotActivity::onConfigure()
+bool ManagedRobotActivity::onConfigure()
 {
   ROS_DEBUG("onConfigure");
-  onManagedConfigure();
+  return onManagedConfigure();
 }
 
-void ManagedRobotActivity::onUnconfigure()
+bool ManagedRobotActivity::onUnconfigure()
 {
   ROS_DEBUG("onUnconfigure");
-  onManagedUnconfigure();
+  return onManagedUnconfigure();
 }
 
-void ManagedRobotActivity::onStart()
+bool ManagedRobotActivity::onStart()
 {
   ROS_DEBUG("onStart");
   service_manager.acquireAll(node_handle_);
   subscriber_manager.acquireAll(node_handle_);
-  onManagedStart();
+  return onManagedStart();
 }
 
-void ManagedRobotActivity::onStop()
+bool ManagedRobotActivity::onStop()
 {
   ROS_DEBUG("onStop");
   service_manager.releaseAll();
   subscriber_manager.releaseAll();
-  onManagedStop();
+  return onManagedStop();
 }
 
-void ManagedRobotActivity::onPause()
+bool ManagedRobotActivity::onPause()
 {
   ROS_DEBUG("onPause");
   service_manager.pauseAll();
   subscriber_manager.pauseAll();
-  onManagedPause();
+  return onManagedPause();
 }
 
-void ManagedRobotActivity::onResume()
+bool ManagedRobotActivity::onResume()
 {
   ROS_DEBUG("onResume");
   service_manager.resumeAll();
   subscriber_manager.resumeAll();
-  onManagedResume();
+  return onManagedResume();
 }
 
 }  // namespace robot_activity

--- a/robot_activity/test/any_robot_activity.cpp
+++ b/robot_activity/test/any_robot_activity.cpp
@@ -56,14 +56,14 @@ private:
   void onCreate() override {};
   void onTerminate() override {};
 
-  void onConfigure() override {};
-  void onUnconfigure() override {};
+  bool onConfigure() override { return true; };
+  bool onUnconfigure() override { return true; };
 
-  void onStart() override {};
-  void onStop() override {};
+  bool onStart() override { return true; };
+  bool onStop() override { return true; };
 
-  void onResume() override {};
-  void onPause() override {};
+  bool onResume() override { return true; };
+  bool onPause() override { return true; };
 };
 
 }  // anonymous namespace

--- a/robot_activity_tutorials/include/robot_activity_tutorials/robot_activity_tutorials.h
+++ b/robot_activity_tutorials/include/robot_activity_tutorials/robot_activity_tutorials.h
@@ -55,14 +55,14 @@ public:
   void onManagedCreate() override;
   void onManagedTerminate() override;
 
-  void onManagedConfigure() override;
-  void onManagedUnconfigure() override;
+  bool onManagedConfigure() override;
+  bool onManagedUnconfigure() override;
 
-  void onManagedStart() override;
-  void onManagedStop() override;
+  bool onManagedStart() override;
+  bool onManagedStop() override;
 
-  void onManagedResume() override;
-  void onManagedPause() override;
+  bool onManagedResume() override;
+  bool onManagedPause() override;
 
 private:
   void timerCallback();

--- a/robot_activity_tutorials/src/robot_activity_tutorials.cpp
+++ b/robot_activity_tutorials/src/robot_activity_tutorials.cpp
@@ -101,36 +101,42 @@ void RobotActivityTutorials::onManagedCreate()
 void RobotActivityTutorials::onManagedTerminate()
 {
   ROS_INFO("onManagedTerminate");
-};
+}
 
-void RobotActivityTutorials::onManagedConfigure()
+bool RobotActivityTutorials::onManagedConfigure()
 {
   ROS_INFO("onManagedConfigure");
+  return true;
 }
 
-void RobotActivityTutorials::onManagedUnconfigure()
+bool RobotActivityTutorials::onManagedUnconfigure()
 {
   ROS_INFO("onManagedUnconfigure");
+  return true;
 }
 
-void RobotActivityTutorials::onManagedStart()
+bool RobotActivityTutorials::onManagedStart()
 {
   ROS_INFO("onManagedStart");
+  return true;
 }
 
-void RobotActivityTutorials::onManagedStop()
+bool RobotActivityTutorials::onManagedStop()
 {
   ROS_INFO("onManagedStop");
+  return true;
 }
 
-void RobotActivityTutorials::onManagedPause()
+bool RobotActivityTutorials::onManagedPause()
 {
   ROS_INFO("onManagedPause");
+  return true;
 }
 
-void RobotActivityTutorials::onManagedResume()
+bool RobotActivityTutorials::onManagedResume()
 {
   ROS_INFO("onManagedResume");
+  return true;
 }
 
 }  // namespace robot_activity_tutorials

--- a/robot_activity_tutorials/src/robot_activity_tutorials_minimal_node.cpp
+++ b/robot_activity_tutorials/src/robot_activity_tutorials_minimal_node.cpp
@@ -67,14 +67,14 @@ private:
   };
   void onManagedTerminate() override {};
 
-  void onManagedConfigure() override {};
-  void onManagedUnconfigure() override {};
+  bool onManagedConfigure() override { return true; };
+  bool onManagedUnconfigure() override { return true; };
 
-  void onManagedStart() override {};
-  void onManagedStop() override {};
+  bool onManagedStart() override { return true; };
+  bool onManagedStop() override { return true; };
 
-  void onManagedResume() override {};
-  void onManagedPause() override {};
+  bool onManagedResume() override { return true; };
+  bool onManagedPause() override { return true; };
 
   void myTimerCallback()
   {


### PR DESCRIPTION
Transition methods from `robot_activity:RobotActivity`:
```
RobotActivity::onConfigure
RobotActivity::onUnconfigure
RobotActivity::onStart
RobotActivity::onStop
RobotActivity::onResume
RobotActivity::onPause
```
and from `robot_activity::ManagedRobotActivity`
```
ManagedRobotActivity::onManagedConfigure
ManagedRobotActivity::onManagedUnconfigure
ManagedRobotActivity::onManagedStart
ManagedRobotActivity::onManagedStop
ManagedRobotActivity::onManagedResume
ManagedRobotActivity::onManagedPause
```
must now return a boolean `(bool)` value indicating whether the transition should succeed or not. If the user, purposely returns `false`, the transition will fail and the state will remain unchanged. On the other hand, returning `true`, will imply that the robot_activity can safely transition to the next state.

**Important**
Methods: `RobotActivity::onCreate`, `RobotActivity::onTerminate`, `ManagedRobotActivity::onManagedCreate`, `ManagedRobotActivity::onManagedTerminate` remain unchanged. As failing in those methods likely indicate that the process should be terminated.