### PR TITLE
Fix concurrent transition callbacks

### DIFF
--- a/robot_activity/src/robot_activity.cpp
+++ b/robot_activity/src/robot_activity.cpp
@@ -142,14 +142,14 @@ RobotActivity& RobotActivity::init(bool autostart)
   if (autostart_)
   {
     auto start = node_handle_private_->serviceClient<std_srvs::Empty>("robot_activity/start");
-    auto ret = start.call(empty);
-    ROS_INFO_STREAM("ret = " << std::boolalpha << ret);
+    start.waitForExistence();
+    start.call(empty);
   }
   else
   {
     auto stop = node_handle_private_->serviceClient<std_srvs::Empty>("robot_activity/stop");
-    auto ret = stop.call(empty);
-    ROS_INFO_STREAM("ret = " << std::boolalpha << ret);
+    stop.waitForExistence();
+    stop.call(empty);
   }
 
   return *this;

--- a/robot_activity/test/robot_activity_tests.cpp
+++ b/robot_activity/test/robot_activity_tests.cpp
@@ -78,7 +78,11 @@ public:
 private:
   void onCreate() override
   {
-    IsolatedAsyncTimer::LambdaCallback cb = [this]() { context++; };
+    IsolatedAsyncTimer::LambdaCallback cb = [this]()
+    {
+      ROS_INFO("context: %d", context);
+      context++;
+    };
     registerIsolatedTimer(cb, 1, stoppable);
   }
 };
@@ -363,6 +367,8 @@ TEST(RobotActivityTests, IsolatedAsyncTimer)
 
   AnyRobotActivityWithTimer test(argc, const_cast<char**>(argv));
   test.init().runAsync();
+  EXPECT_EQ(test.getState(), State::RUNNING);
+
   ros::Duration(2.1).sleep();
   EXPECT_EQ(test.context, 2);
 }

--- a/robot_activity/test/robot_activity_tests.cpp
+++ b/robot_activity/test/robot_activity_tests.cpp
@@ -80,7 +80,7 @@ private:
   {
     IsolatedAsyncTimer::LambdaCallback cb = [this]()
     {
-      ROS_INFO("context: %d", context);
+      std::cout << "context: " << context << std::endl;
       context++;
     };
     registerIsolatedTimer(cb, 1, stoppable);
@@ -392,6 +392,8 @@ TEST(RobotActivityTests, StoppableIsolatedAsyncTimer)
   AnyRobotActivityWithTimer test(argc, const_cast<char**>(argv));
   test.init().runAsync();
 
+  EXPECT_EQ(test.getState(), State::RUNNING);
+
   ros::Duration(1.1).sleep();
   EXPECT_EQ(test.context, 1);
   EXPECT_EQ(pause.call(pause_empty), true);
@@ -420,6 +422,8 @@ TEST(RobotActivityTests, NonStoppableIsolatedAsyncTimer)
   AnyRobotActivityWithTimer test(argc, const_cast<char**>(argv));
   test.stoppable = false;
   test.init().runAsync();
+
+  EXPECT_EQ(test.getState(), State::RUNNING);
 
   ros::Duration(1.1).sleep();
   EXPECT_EQ(test.context, 1);


### PR DESCRIPTION
Fixing #2 

Since transition services (`/start`, `/stop`, etc) are on a separate callback queue with a single thread serving them, they are synchronized. Therefore, to fix this issue, we simply call the first transition in `init()` call via service and all other call will be synchronized.